### PR TITLE
fix: drop stale async spread writes so cover can't land on page 2 (Content_91)

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -251,6 +251,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
   currentChapterLink: D2Link = { href: "" };
   currentSpreadLinks: { left?: D2Link; right?: D2Link } = {};
+  // Bumped per spread render so a stale async iframe write (e.g. the cover
+  // resolving late onto page 2) is dropped instead of clobbering the spread.
+  private spreadRenderGeneration = 0;
   currentTOCRawLink: string;
   private nextChapterLink: D2Link | undefined;
   private previousChapterLink: D2Link | undefined;
@@ -1736,7 +1739,11 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
     this.currentSpreadLinks = {};
 
+    // Newer render wins: the writes below bail once this token is superseded.
+    const renderGeneration = ++this.spreadRenderGeneration;
+
     function writeIframeDoc(content: string, href: string) {
+      if (renderGeneration !== self.spreadRenderGeneration) return;
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, "application/xhtml+xml");
       if (doc.head) {
@@ -1758,6 +1765,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
     }
 
     function writeIframe2Doc(content: string, href: string) {
+      if (renderGeneration !== self.spreadRenderGeneration) return;
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, "application/xhtml+xml");
       if (doc.head) {


### PR DESCRIPTION
## Problem

On fixed-layout books the **cover renders on page 2 of the first content spread** and the reader gets stuck ("can't move forward"). It's intermittent, and **a refresh usually clears it** — the classic tell of a race plus a persisted reading position.

Reported as Content_91 ("Cover shows on pg 2 in Listen & Read Along").

### In plain terms (for non-technical reviewers)

![What the bug looks like to a reader](https://github.com/reading-innovation/R2D2BC/blob/3100da9db189ae5475c2aab7b22c7e051cc42ccd/docs/content91-explainer.png?raw=true)

### Reproduced (consumer app, fixed-layout phonics book KD_1)

Left pane = page 1 text; right pane / page 2 = the cover. Reader is stuck here.

![Content_91 reproduced: cover on page 2](https://github.com/reading-innovation/R2D2BC/blob/4b7badd1e880d8439b428e4ee2e2edc0ae5f35ab/docs/content91-cover-on-pg2.png?raw=true)

## Root cause

`precessContentForIframe()` renders a fixed-layout spread by writing content into the two shared iframes **asynchronously** (`fetch(href).then(...) -> writeIframeDoc / writeIframe2Doc`). On a clean first load two render cycles run back-to-back, and **both write `iframes[1]` with no cancellation guard** — whichever `fetch` resolves last wins:

```
precessContentForIframe()  — runs per navigation; both renders write the SHARED iframes[0]/[1]

  RENDER A   initial load -> spine 0 = COVER   (even branch)
     iframes[0].src = about:blank
     fetch(cover.xhtml) ------------------------------+   async
                                                      |
  RENDER B   consumer goToPosition -> spine 1 = page1 (odd branch, fires right after A)
     fetch(page1.xhtml) ------------+                 |
     fetch(page2.xhtml) --------+   |                 |
                               |    |                 |
   time ----------------------- v -- v --------------- v ------->
     writeIframeDoc (page1)  -> iframes[0]   left  = page1   OK
     writeIframe2Doc(page2)  -> iframes[1]   right = page2   OK
     writeIframe2Doc(cover)  -> iframes[1]   right = COVER   STALE  <- resolves last, wins
                                              +---------------- "cover on pg 2", reader stuck
```

Once a reading position is stored, the initial cover render is skipped on later loads — which is why **a refresh appears to fix it**.

Related (not required for this fix): spread pairing is pure spine-index parity (`even = index % 2 === 1`) and `page-spread` / `page-spread-center` is never read, so the cover is structurally forced onto the right pane. Worth tracking as a deeper cleanup.

## Fix

Snapshot a monotonic `spreadRenderGeneration` at the start of `precessContentForIframe()` and bail out of both `writeIframe*Doc` helpers when a newer render has superseded this one. Stale writes are dropped; the newest navigation always owns the spread. No timing heuristic, no change to the two-up spread visuals. ~8 lines.

```
  const renderGeneration = ++this.spreadRenderGeneration;   // bump per render
  writeIframe2Doc = (...) => { if (renderGeneration !== self.spreadRenderGeneration) return; ... }
  //  RENDER B bumps the token -> RENDER A's late cover write is discarded
```

## Reproduction & verification

Driven in the consumer app with Playwright (fixed-layout phonics book KD_1). Warm cache + a stored reading position hide the race, so it only surfaces on a clean first load with cover-resource latency:

| Load | Condition | Result |
|---|---|---|
| 1-6 | warm / default | correct (page1 \| page2) |
| 7 | cover latency, **reading position restored** | correct  <- this is "refresh fixes it" |
| 8 | cover latency + **reading position cleared** | **BUG: cover on page 2** |

- 8 loads -> 7 correct, 1 reproduced; the failure needs clean-storage + cover latency to line up, which matches the intermittent field reports.
- `tsc --noEmit` passes clean.

## Scope / notes

- Targets the cross-origin `fetch -> writeIframe*Doc` path, which is the one the consumer app uses (content served from a separate streamer origin). The same-origin `iframes[x].src = ...` assignments inside `.then` callbacks share the same latent race but are out of scope here; can follow up if any deployment serves content same-origin.
- The reproduction screenshot lives on the `assets/content91-repro` branch to keep this fix's diff to source only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
