### PR TITLE
fix: fall back to other spread page when current has no media overlay

### DIFF
--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -165,7 +165,13 @@ export class MediaOverlayModule implements ReaderModule {
     return link?.HrefDecoded || link?.Href || undefined;
   }
 
-  /** Safer than indexOf(substring): avoids "1.xhtml" matching inside "11.xhtml". */
+  private pathBasename(path: string): string {
+    const cleaned = path.replace(/\\/g, "/").replace(/\/$/, "");
+    const parts = cleaned.split("/");
+    return parts[parts.length - 1] || cleaned;
+  }
+
+  /** Match chapter URL to a spine/link href without substring false positives. */
   private hrefMatchesChapter(
     linkHref: string | undefined,
     chapterHref: string | undefined
@@ -175,16 +181,13 @@ export class MediaOverlayModule implements ReaderModule {
     try {
       const chapterPath = new URL(chapterHref, "https://dita.digital/").pathname;
       const linkPath = new URL(linkHref, "https://dita.digital/").pathname;
-      return (
-        chapterPath === linkPath ||
-        chapterPath.endsWith("/" + linkPath.replace(/^\//, "")) ||
-        chapterPath.endsWith(linkPath)
-      );
+      if (chapterPath === linkPath) return true;
+      // Require a path-segment boundary ("/1.xhtml" not "11.xhtml").
+      if (chapterPath.endsWith("/" + linkPath.replace(/^\//, ""))) return true;
+      return this.pathBasename(chapterPath) === this.pathBasename(linkPath);
     } catch {
-      return (
-        chapterHref.endsWith(linkHref) ||
-        chapterHref.endsWith("/" + linkHref.replace(/^\//, ""))
-      );
+      if (chapterHref.endsWith("/" + linkHref.replace(/^\//, ""))) return true;
+      return this.pathBasename(chapterHref) === this.pathBasename(linkHref);
     }
   }
 
@@ -200,8 +203,20 @@ export class MediaOverlayModule implements ReaderModule {
     }
   }
 
-  /** Next spread page with a media overlay, scanning forward then wrapping. */
-  private findNextMediaOverlayLinkIndex(
+  /** Forward-only: next higher index with MO (no wrap — avoids replaying the page we just finished). */
+  private findForwardMediaOverlayLinkIndex(
+    fromIndex: number = this.currentLinkIndex
+  ): number {
+    for (let i = fromIndex + 1; i < this.currentLinks.length; i++) {
+      if (this.currentLinks[i]?.Properties?.MediaOverlay) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Any other spread page with MO (including earlier indices). For "current has no audio". */
+  private findOtherMediaOverlayLinkIndex(
     fromIndex: number = this.currentLinkIndex
   ): number {
     const n = this.currentLinks.length;
@@ -215,8 +230,8 @@ export class MediaOverlayModule implements ReaderModule {
     return -1;
   }
 
-  private async playNextMediaOverlayLinkOrAdvance(): Promise<void> {
-    const next = this.findNextMediaOverlayLinkIndex(this.currentLinkIndex);
+  private async advanceAfterMediaOverlayOrStop(): Promise<void> {
+    const next = this.findForwardMediaOverlayLinkIndex(this.currentLinkIndex);
     if (next >= 0) {
       this.currentLinkIndex = next;
       await this.playLink();
@@ -226,9 +241,23 @@ export class MediaOverlayModule implements ReaderModule {
       await this.audioElement.pause();
     }
     if (this.settings.autoTurn && this.settings.playing) {
-      if (this.audioElement) {
-        await this.audioElement.pause();
-      }
+      this.navigator.nextResource();
+    } else {
+      await this.stopReadAloud();
+    }
+  }
+
+  private async playOtherMediaOverlayLinkOrAdvance(): Promise<void> {
+    const next = this.findOtherMediaOverlayLinkIndex(this.currentLinkIndex);
+    if (next >= 0) {
+      this.currentLinkIndex = next;
+      await this.playLink();
+      return;
+    }
+    if (this.audioElement) {
+      await this.audioElement.pause();
+    }
+    if (this.settings.autoTurn && this.settings.playing) {
       this.navigator.nextResource();
     } else {
       await this.stopReadAloud();
@@ -284,7 +313,7 @@ export class MediaOverlayModule implements ReaderModule {
       if (this.audioElement) {
         await this.audioElement.pause();
       }
-      await this.playNextMediaOverlayLinkOrAdvance();
+      await this.playOtherMediaOverlayLinkOrAdvance();
     }
   }
 
@@ -308,7 +337,7 @@ export class MediaOverlayModule implements ReaderModule {
         this.audioElement.volume = this.settings.volume;
         this.audioElement.playbackRate = this.settings.rate;
       } else {
-        await this.playNextMediaOverlayLinkOrAdvance();
+        await this.playOtherMediaOverlayLinkOrAdvance();
       }
       if (this.play) this.play.style.display = "none";
       if (this.pause) this.pause.style.removeProperty("display");
@@ -787,7 +816,7 @@ export class MediaOverlayModule implements ReaderModule {
         log.log("mediaOverlaysNext() - navLeftOrRight()");
         this.mediaOverlaysStop();
 
-        void this.playNextMediaOverlayLinkOrAdvance();
+        void this.advanceAfterMediaOverlayOrStop();
       } else {
         let switchDoc = false;
         if (this.mediaOverlayTextAudioPair.Text && nextTextAudioPair.Text) {
@@ -824,7 +853,7 @@ export class MediaOverlayModule implements ReaderModule {
       log.log("mediaOverlaysNext() - navLeftOrRight() 2");
       this.mediaOverlaysStop();
 
-      void this.playNextMediaOverlayLinkOrAdvance();
+      void this.advanceAfterMediaOverlayOrStop();
     }
   }
   mediaOverlaysStop() {
@@ -1086,7 +1115,7 @@ export class MediaOverlayModule implements ReaderModule {
 
       const onended = async (_ev: Event) => {
         log.log("onended");
-        await this.playNextMediaOverlayLinkOrAdvance();
+        await this.advanceAfterMediaOverlayOrStop();
       };
       this.audioElement.addEventListener("ended", onended);
 

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -160,6 +160,81 @@ export class MediaOverlayModule implements ReaderModule {
     await this.playLink();
   }
 
+
+  private getLinkHref(link?: Link): string | undefined {
+    return link?.HrefDecoded || link?.Href || undefined;
+  }
+
+  /** Safer than indexOf(substring): avoids "1.xhtml" matching inside "11.xhtml". */
+  private hrefMatchesChapter(
+    linkHref: string | undefined,
+    chapterHref: string | undefined
+  ): boolean {
+    if (!linkHref || !chapterHref) return false;
+    if (chapterHref === linkHref) return true;
+    try {
+      const chapterPath = new URL(chapterHref, "https://dita.digital/").pathname;
+      const linkPath = new URL(linkHref, "https://dita.digital/").pathname;
+      return (
+        chapterPath === linkPath ||
+        chapterPath.endsWith("/" + linkPath.replace(/^\//, "")) ||
+        chapterPath.endsWith(linkPath)
+      );
+    } catch {
+      return (
+        chapterHref.endsWith(linkHref) ||
+        chapterHref.endsWith("/" + linkHref.replace(/^\//, ""))
+      );
+    }
+  }
+
+  private syncCurrentLinkIndexToChapter(): void {
+    if (this.currentLinks.length <= 1) return;
+    const currentHref = this.navigator.currentChapterLink?.href;
+    if (!currentHref) return;
+    const matchIndex = this.currentLinks.findIndex((l) =>
+      this.hrefMatchesChapter(this.getLinkHref(l), currentHref)
+    );
+    if (matchIndex >= 0) {
+      this.currentLinkIndex = matchIndex;
+    }
+  }
+
+  /** Next spread page with a media overlay, scanning forward then wrapping. */
+  private findNextMediaOverlayLinkIndex(
+    fromIndex: number = this.currentLinkIndex
+  ): number {
+    const n = this.currentLinks.length;
+    if (n <= 1) return -1;
+    for (let step = 1; step < n; step++) {
+      const i = (fromIndex + step) % n;
+      if (this.currentLinks[i]?.Properties?.MediaOverlay) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private async playNextMediaOverlayLinkOrAdvance(): Promise<void> {
+    const next = this.findNextMediaOverlayLinkIndex(this.currentLinkIndex);
+    if (next >= 0) {
+      this.currentLinkIndex = next;
+      await this.playLink();
+      return;
+    }
+    if (this.audioElement) {
+      await this.audioElement.pause();
+    }
+    if (this.settings.autoTurn && this.settings.playing) {
+      if (this.audioElement) {
+        await this.audioElement.pause();
+      }
+      this.navigator.nextResource();
+    } else {
+      await this.stopReadAloud();
+    }
+  }
+
   private async playLink() {
     let link = this.currentLinks[this.currentLinkIndex];
     if (link?.Properties?.MediaOverlay) {
@@ -209,19 +284,7 @@ export class MediaOverlayModule implements ReaderModule {
       if (this.audioElement) {
         await this.audioElement.pause();
       }
-      if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-        this.currentLinkIndex++;
-        await this.playLink();
-      } else {
-        if (this.settings.autoTurn && this.settings.playing) {
-          if (this.audioElement) {
-            await this.audioElement.pause();
-          }
-          this.navigator.nextResource();
-        } else {
-          await this.stopReadAloud();
-        }
-      }
+      await this.playNextMediaOverlayLinkOrAdvance();
     }
   }
 
@@ -231,6 +294,7 @@ export class MediaOverlayModule implements ReaderModule {
       this.mediaOverlayNodesForSegment = [];
 
       this.settings.playing = true;
+      this.syncCurrentLinkIndexToChapter();
       if (
         this.audioElement &&
         this.currentLinks[this.currentLinkIndex]?.Properties?.MediaOverlay
@@ -244,16 +308,7 @@ export class MediaOverlayModule implements ReaderModule {
         this.audioElement.volume = this.settings.volume;
         this.audioElement.playbackRate = this.settings.rate;
       } else {
-        if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-          this.currentLinkIndex++;
-          await this.playLink();
-        } else {
-          if (this.settings.autoTurn && this.settings.playing) {
-            this.navigator.nextResource();
-          } else {
-            await this.stopReadAloud();
-          }
-        }
+        await this.playNextMediaOverlayLinkOrAdvance();
       }
       if (this.play) this.play.style.display = "none";
       if (this.pause) this.pause.style.removeProperty("display");
@@ -286,18 +341,7 @@ export class MediaOverlayModule implements ReaderModule {
         // Prefer the navigator's current page within a two-up spread so we don't
         // greedily re-match the left page (which caused "read the same page twice"
         // when every page's audio shares the same time offsets).
-        if (this.currentLinks.length > 1) {
-          const currentHref = this.navigator.currentChapterLink?.href;
-          if (currentHref) {
-            const matchIndex = this.currentLinks.findIndex((l) => {
-              const href = l?.HrefDecoded || l?.Href;
-              return href ? currentHref.indexOf(href) !== -1 : false;
-            });
-            if (matchIndex >= 0) {
-              this.currentLinkIndex = matchIndex;
-            }
-          }
-        }
+        this.syncCurrentLinkIndexToChapter();
 
         if (!this.audioElement) {
           this.isSegmentMode = false;
@@ -359,12 +403,19 @@ export class MediaOverlayModule implements ReaderModule {
                 targetTime: endTime,
               });
 
+            const preferredIndex = candidateOrder[0];
             const hasOtherMoCandidate = candidateOrder.some(
               (i) =>
                 i !== index &&
                 !!this.currentLinks[i]?.Properties?.MediaOverlay
             );
-            if (!timeMatches && hasOtherMoCandidate) {
+            // Soft time mismatch on the preferred page: still play it (float
+            // error / shared offsets). Only abandon non-preferred candidates.
+            if (
+              !timeMatches &&
+              hasOtherMoCandidate &&
+              index !== preferredIndex
+            ) {
               continue;
             }
 
@@ -736,18 +787,7 @@ export class MediaOverlayModule implements ReaderModule {
         log.log("mediaOverlaysNext() - navLeftOrRight()");
         this.mediaOverlaysStop();
 
-        if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-          this.currentLinkIndex++;
-          this.playLink();
-        } else {
-          this.audioElement.pause();
-          if (this.settings.autoTurn && this.settings.playing) {
-            this.audioElement.pause();
-            this.navigator.nextResource();
-          } else {
-            this.stopReadAloud();
-          }
-        }
+        void this.playNextMediaOverlayLinkOrAdvance();
       } else {
         let switchDoc = false;
         if (this.mediaOverlayTextAudioPair.Text && nextTextAudioPair.Text) {
@@ -784,18 +824,7 @@ export class MediaOverlayModule implements ReaderModule {
       log.log("mediaOverlaysNext() - navLeftOrRight() 2");
       this.mediaOverlaysStop();
 
-      if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-        this.currentLinkIndex++;
-        this.playLink();
-      } else {
-        this.audioElement.pause();
-        if (this.settings.autoTurn && this.settings.playing) {
-          this.audioElement.pause();
-          this.navigator.nextResource();
-        } else {
-          this.stopReadAloud();
-        }
-      }
+      void this.playNextMediaOverlayLinkOrAdvance();
     }
   }
   mediaOverlaysStop() {
@@ -1057,17 +1086,7 @@ export class MediaOverlayModule implements ReaderModule {
 
       const onended = async (_ev: Event) => {
         log.log("onended");
-        if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-          this.currentLinkIndex++;
-          await this.playLink();
-        } else {
-          if (this.settings.autoTurn && this.settings.playing) {
-            this.audioElement.pause();
-            this.navigator.nextResource();
-          } else {
-            this.stopReadAloud();
-          }
-        }
+        await this.playNextMediaOverlayLinkOrAdvance();
       };
       this.audioElement.addEventListener("ended", onended);
 

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -816,7 +816,9 @@ export class MediaOverlayModule implements ReaderModule {
         log.log("mediaOverlaysNext() - navLeftOrRight()");
         this.mediaOverlaysStop();
 
-        void this.advanceAfterMediaOverlayOrStop();
+        void this.advanceAfterMediaOverlayOrStop().catch((e) =>
+          console.error(e)
+        );
       } else {
         let switchDoc = false;
         if (this.mediaOverlayTextAudioPair.Text && nextTextAudioPair.Text) {
@@ -853,7 +855,9 @@ export class MediaOverlayModule implements ReaderModule {
       log.log("mediaOverlaysNext() - navLeftOrRight() 2");
       this.mediaOverlaysStop();
 
-      void this.advanceAfterMediaOverlayOrStop();
+      void this.advanceAfterMediaOverlayOrStop().catch((e) =>
+        console.error(e)
+      );
     }
   }
   mediaOverlaysStop() {

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -283,11 +283,9 @@ export class MediaOverlayModule implements ReaderModule {
         this.isSegmentMode = true;
         this.settings.playing = true;
 
-        // A two-up spread loads both pages into currentLinks with
-        // currentLinkIndex defaulting to the left page. Re-point it to the page
-        // the navigator is actually on, so per-page media-overlay audio plays on
-        // the correct page instead of greedily re-matching the spread's first
-        // page (which caused fixed-layout books to "read the same page twice").
+        // Prefer the navigator's current page within a two-up spread so we don't
+        // greedily re-match the left page (which caused "read the same page twice"
+        // when every page's audio shares the same time offsets).
         if (this.currentLinks.length > 1) {
           const currentHref = this.navigator.currentChapterLink?.href;
           if (currentHref) {
@@ -301,80 +299,99 @@ export class MediaOverlayModule implements ReaderModule {
           }
         }
 
-        if (
-          this.audioElement &&
-          this.currentLinks[this.currentLinkIndex]?.Properties?.MediaOverlay
-        ) {
-          this.currentAudioBegin = startTime;
-          this.currentAudioEnd = endTime;
-
-          this.mediaOverlayNodesForSegment = [];
-          await this.setMediaOverlayTextAudioPairForTimeRange(
-            startTime,
-            endTime
-          );
-
-          if (this.mediaOverlayNodesForSegment.length === 0) {
-            if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-              this.currentLinkIndex++;
-              this.startReadAloudBySegment({ startTime, endTime });
-              return;
-            } else {
-              console.error(
-                "No matching node found for time range",
-                startTime,
-                endTime
-              );
-
-              this.isSegmentMode = false;
-              this.settings.playing = false;
-            }
-            return;
-          }
-
-          this.mediaOverlayNodesForSegment.sort((a, b) => {
-            const aStartTime = this.getAudioTimeRangeFromNode(a)?.[0];
-            const bStartTime = this.getAudioTimeRangeFromNode(b)?.[0];
-            return Number(aStartTime) - Number(bStartTime);
-          });
-
-          const firstNodeTimeRange = this.getAudioTimeRangeFromNode(
-            this.mediaOverlayNodesForSegment[0]
-          );
-          const lastNodeTimeRange = this.getAudioTimeRangeFromNode(
-            this.mediaOverlayNodesForSegment[
-              this.mediaOverlayNodesForSegment.length - 1
-            ]
-          );
-
-          if (
-            !checkIsTimeInRange({
-              currentTime: firstNodeTimeRange?.[0] || 0,
-              targetTime: startTime,
-            }) ||
-            !checkIsTimeInRange({
-              currentTime: lastNodeTimeRange?.[1] || 0,
-              targetTime: endTime,
-            })
-          ) {
-            if (this.currentLinks.length > 1 && this.currentLinkIndex === 0) {
-              this.currentLinkIndex++;
-              this.mediaOverlayNodesForSegment = [];
-              this.startReadAloudBySegment({ startTime, endTime });
-              return;
+        if (!this.audioElement) {
+          this.isSegmentMode = false;
+          this.settings.playing = false;
+        } else {
+          // Try current page first, then any other spread page that has a media
+          // overlay. Illustration-only pages have no MO — without this fallback,
+          // play becomes a silent no-op when currentChapterLink is the image side.
+          const candidateOrder: number[] = [this.currentLinkIndex];
+          for (let i = 0; i < this.currentLinks.length; i++) {
+            if (i !== this.currentLinkIndex) {
+              candidateOrder.push(i);
             }
           }
 
-          this.mediaOverlayTextAudioPair = this.mediaOverlayNodesForSegment[0];
+          let played = false;
+          for (const index of candidateOrder) {
+            const link = this.currentLinks[index];
+            if (!link?.Properties?.MediaOverlay) {
+              continue;
+            }
 
-          await this.playMediaOverlaysAudio(
-            this.mediaOverlayTextAudioPair,
-            firstNodeTimeRange?.[0],
-            firstNodeTimeRange?.[1]
-          );
+            this.currentLinkIndex = index;
+            this.currentAudioBegin = startTime;
+            this.currentAudioEnd = endTime;
+            this.mediaOverlayNodesForSegment = [];
 
-          this.audioElement.volume = this.settings.volume;
-          this.audioElement.playbackRate = this.settings.rate;
+            await this.setMediaOverlayTextAudioPairForTimeRange(
+              startTime,
+              endTime
+            );
+
+            if (this.mediaOverlayNodesForSegment.length === 0) {
+              continue;
+            }
+
+            this.mediaOverlayNodesForSegment.sort((a, b) => {
+              const aStartTime = this.getAudioTimeRangeFromNode(a)?.[0];
+              const bStartTime = this.getAudioTimeRangeFromNode(b)?.[0];
+              return Number(aStartTime) - Number(bStartTime);
+            });
+
+            const firstNodeTimeRange = this.getAudioTimeRangeFromNode(
+              this.mediaOverlayNodesForSegment[0]
+            );
+            const lastNodeTimeRange = this.getAudioTimeRangeFromNode(
+              this.mediaOverlayNodesForSegment[
+                this.mediaOverlayNodesForSegment.length - 1
+              ]
+            );
+
+            const timeMatches =
+              checkIsTimeInRange({
+                currentTime: firstNodeTimeRange?.[0] || 0,
+                targetTime: startTime,
+              }) &&
+              checkIsTimeInRange({
+                currentTime: lastNodeTimeRange?.[1] || 0,
+                targetTime: endTime,
+              });
+
+            const hasOtherMoCandidate = candidateOrder.some(
+              (i) =>
+                i !== index &&
+                !!this.currentLinks[i]?.Properties?.MediaOverlay
+            );
+            if (!timeMatches && hasOtherMoCandidate) {
+              continue;
+            }
+
+            this.mediaOverlayTextAudioPair =
+              this.mediaOverlayNodesForSegment[0];
+
+            await this.playMediaOverlaysAudio(
+              this.mediaOverlayTextAudioPair,
+              firstNodeTimeRange?.[0],
+              firstNodeTimeRange?.[1]
+            );
+
+            this.audioElement.volume = this.settings.volume;
+            this.audioElement.playbackRate = this.settings.rate;
+            played = true;
+            break;
+          }
+
+          if (!played) {
+            console.error(
+              "No matching node found for time range",
+              startTime,
+              endTime
+            );
+            this.isSegmentMode = false;
+            this.settings.playing = false;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes silent media-overlay playback on two-up fixed-layout spreads when the navigator’s current page is an illustration (no audio) while the facing text page owns the media overlay.

This showed up in Reading Space phonics **Let’s Read a Story → Listen**, which navigates with `page.order + 2` so the spread shows `[text | illustration]`. After R2D2BC started following `currentChapterLink` strictly, play called `startReadAloudBySegment` successfully but produced **no sound**.

## What happened (timeline)

### Before (accidental “works”)
- Two-up spread: `[ TEXT (has audio) | PICTURE (no audio) ]`
- App often treated the **picture** page as current (layout)
- Old reader greedily searched the **left** page first
- Result: text audio still played (lucky), but other books could “read the same page twice” when every page shared the same time offsets

### Jul 7 — `10265e6` (correct fix, new failure mode)
- `startReadAloudBySegment` re-points `currentLinkIndex` to `currentChapterLink`
- Stops wrong-page / same-page-twice playback
- Side effect: if current chapter is the **illustration**, there is no media overlay → **silent no-op** (no error UI)

### Jul 10 — `765c46e`
- Separate spread race: drop stale async iframe writes so cover can’t land on page 2
- Related to spreads, not the silence itself

### This PR
- Keep “prefer current page” (preserve `10265e6`)
- If that page has no usable media overlay, try **other pages in the current spread** that do
- Harden the same pattern across all MO advance paths, not only segment play

## Fixes in this PR

### 1. Segment play (`startReadAloudBySegment`) — primary phonics path
- Prefer navigator current page within the spread
- Candidate order: `[current, ...other spread links]`
- Skip pages with no `MediaOverlay`
- If no matching MO nodes, try next candidate
- Soft time-mismatch on the **preferred** page: still play it (avoids bouncing to the wrong page when every page shares similar `start`/`end` offsets)
- Soft time-mismatch on **non-preferred** candidates: skip and keep searching
- If nothing plays: `console.error` + reset playing flags (no silent hang)

### 2. Shared spread fallback helper
- `playNextMediaOverlayLinkOrAdvance()` finds **any** other spread page with MO (not only `0 → 1`)
- Used by:
  - `playLink` (current page has no MO)
  - `startReadAloud` (full read-along)
  - `mediaOverlaysNext` (end of page MO)
  - audio `ended` handler

### 3. Safer chapter ↔ link href matching
- Replaces bare `chapterHref.indexOf(linkHref)` (could match `"1.xhtml"` inside `"11.xhtml"`)
- Uses path equality / suffix matching via `hrefMatchesChapter()`

### 4. Sync helpers
- `syncCurrentLinkIndexToChapter()` centralizes “prefer current chapter in spread”
- Used by segment play and full `startReadAloud`

## What this does **not** change
- App layout offsets (e.g. phonics `+2`) stay valid — reader is resilient when current = illustration
- Highlight iframe selection still uses `currentLinkIndex === 0` vs `1` (left/right iframe), which is correct

## How to verify

- [ ] Fixed-layout two-up: current = **text** page → play segment → that page’s audio plays
- [ ] Same book: current = **illustration** facing page → play segment → facing text audio still plays (no silence)
- [ ] Both spread pages have MO with **distinct** timings → preferred/current page wins
- [ ] Both pages share similar offsets → does **not** replay the wrong page twice
- [ ] Full read-along / next / ended: if current page has no MO, advances to the other spread page with MO before leaving the spread
- [ ] Phonics Let’s Read a Story Listen (`unitId` with two-up reader) → tap play → sound works with text+illustration layout

## Reading Space context
- Learner depends on `@d-i-t-a/reader` from this repo
- After merge: bump the learner lockfile to this commit so installs pick up the fix (local `node_modules` patches won’t survive reinstall)
